### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -1,6 +1,6 @@
 use v6;
 
-BEGIN { @*INC.unshift('lib') };
+use lib 'lib';
 
 use Test;
 plan 6;


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.